### PR TITLE
Support nullable properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,41 @@ Done! ✌️
 
 The `Primitives<Course>` return type is ensuring all our restrictions in a very straighforward way! 🌈
 
+## ❔ Nullable properties support
+
+The `Primitives<T>` type also supports nullable properties. 
+
+Let's say we add a `teacherId` to our `Course`, which can be null:
+
+```typescript
+import { Primitives } from "@codelytv/primitives-type";
+
+import { CourseId } from "./CourseId";
+import { CourseTitle } from "./CourseTitle";
+import { TeacherId } from "./TeacherId";
+
+export class Course {
+  constructor(readonly courseId: CourseId, readonly courseTitle: CourseTitle, readonly teacherId: TeacherId | null) {
+  }
+
+  updateTitle(newCourseTitle: CourseTitle): void {
+    this.courseTitle = newCourseTitle;
+  }
+
+  someOtherMethodWithDomainLogic(): void {
+    // some algorithm
+  }
+
+  toPrimitives(): Primitives<Course> {
+    return {
+      courseId: this.courseId.value,
+      courseTitle: this.courseTitle.value,
+      teacherId: this.teacherId?.value ?? null // <- Nullable property
+    };
+  }
+}
+```
+
 # 👍 How to install
 
 - Npm: `npm install |--save-dev @codelytv/primitives-type`

--- a/src/Primitives.ts
+++ b/src/Primitives.ts
@@ -3,6 +3,8 @@ type Methods<T> = {
   [P in keyof T]: T[P] extends Function ? P : never;
 }[keyof T];
 
+type Nullable<T> = T | null;
+
 type MethodsAndProperties<T> = { [key in keyof T]: T[key] };
 
 type Properties<T> = Omit<MethodsAndProperties<T>, Methods<T>>;
@@ -17,4 +19,4 @@ type ValueObjectValue<T> = {
     : T[key];
 };
 
-export type Primitives<T> = ValueObjectValue<Properties<T>>;
+export type Primitives<T> = ValueObjectValue<Properties<Nullable<T>>>;

--- a/tests/Course.ts
+++ b/tests/Course.ts
@@ -1,12 +1,17 @@
-import { Primitives } from "../src/Primitives";
+import { Primitives } from "../src";
 import { CourseId } from "./CourseId";
+import { TeacherId } from "./TeacherId";
 
 export class Course {
-  constructor(readonly courseId: CourseId) {}
+  constructor(
+    readonly courseId: CourseId,
+    readonly teacherId: TeacherId | null
+  ) {}
 
   toPrimitives(): Primitives<Course> {
     return {
       courseId: this.courseId.value,
+      teacherId: this.teacherId?.value ?? null,
     };
   }
 

--- a/tests/Primitives.test.ts
+++ b/tests/Primitives.test.ts
@@ -1,13 +1,33 @@
 import { Course } from "./Course";
 import { CourseId } from "./CourseId";
+import { TeacherId } from "./TeacherId";
 
 describe("Primitives", () => {
   it("should ensure to only return primitive properties excluding methods", () => {
-    const course = new Course(new CourseId("course-id"));
+    const course = new Course(
+      new CourseId("course-id"),
+      new TeacherId("teacher-id")
+    );
 
     const actualPrimitives = course.toPrimitives();
 
-    const expectedPrimitives = { courseId: "course-id" };
+    const expectedPrimitives = {
+      courseId: "course-id",
+      teacherId: "teacher-id",
+    };
+
+    expect(actualPrimitives).toEqual(expectedPrimitives);
+  });
+
+  it("should accept nullable properties", () => {
+    const course = new Course(new CourseId("course-id"), null);
+
+    const actualPrimitives = course.toPrimitives();
+
+    const expectedPrimitives = {
+      courseId: "course-id",
+      teacherId: null,
+    };
 
     expect(actualPrimitives).toEqual(expectedPrimitives);
   });

--- a/tests/TeacherId.ts
+++ b/tests/TeacherId.ts
@@ -1,0 +1,3 @@
+import { StringValueObject } from "./StringValueObject";
+
+export class TeacherId extends StringValueObject {}


### PR DESCRIPTION
When I tried to use this type in one of my projects, I noticed that it does not support nullable properties.

I added a `Nullable` type inside the `Primitives.ts` file, and then used it as the generic in `Properties`, so the new `Primitives` type looks like this:

```typescript
type Nullable<T> = T | null;
export type Primitives<T> = ValueObjectValue<Properties<Nullable<T>>>;
```

To test it, I added a nullable property to `Course` and create an specific test for this feature. This addition forced me to also change the existing test.