### PR TITLE
 Add MutablePrimitives.ts for cases when creating editable objects.

### DIFF
--- a/src/MutablePrimitives.ts
+++ b/src/MutablePrimitives.ts
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/ban-types */
+type Methods<T> = {
+  [P in keyof T]: T[P] extends Function ? P : never;
+}[keyof T];
+
+type MethodsAndProperties<T> = { [key in keyof T]: T[key] };
+
+type NonReadonly<T> = {
+  -readonly [P in keyof T]: T[P];
+};
+
+type Properties<T> = Omit<MethodsAndProperties<NonReadonly<T>>, Methods<T>>;
+
+type PrimitiveTypes = string | number | boolean | Date | undefined | null;
+
+type ValueObjectValue<T> = T extends PrimitiveTypes
+  ? T
+  : T extends { value: infer U }
+    ? U
+    : T extends Array<{ value: infer U }>
+      ? U[]
+      : T extends Array<infer U>
+        ? Array<ValueObjectValue<U>>
+        : T extends { [K in keyof Properties<T>]: infer U }
+          ? { [K in keyof Properties<T>]: ValueObjectValue<Properties<T>[K]> }
+          : never;
+
+export type MutablePrimitives<T> = {
+  [key in keyof Properties<T>]: ValueObjectValue<T[key]>;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import { Primitives } from "./Primitives";
+import { MutablePrimitives } from "./MutablePrimitives";
 
-export { Primitives };
+export { Primitives, MutablePrimitives };

--- a/tests/MutablePrimitives.test.ts
+++ b/tests/MutablePrimitives.test.ts
@@ -1,0 +1,81 @@
+import { expectTypeOf } from "expect-type";
+import { MutablePrimitives } from "../src";
+import { Course } from "./Course";
+import { DeliveryInfo } from "./DeliveryInfo";
+import { Learner } from "./Learner";
+import { Product } from "./Product";
+import { User } from "./User";
+import { Video } from "./Video";
+
+describe("MutablePrimitives", () => {
+  it("should ensure to only return primitive properties excluding methods", () => {
+    type actualPrimitives = MutablePrimitives<Course>;
+
+    type expectedPrimitives = {
+       courseId: string;
+    };
+
+    expectTypeOf<actualPrimitives>().toEqualTypeOf<expectedPrimitives>();
+  });
+
+  it("should get primitive array type from value object array", () => {
+    type actualPrimitives = MutablePrimitives<Learner>;
+
+    type expectedPrimitives = {
+       enrolledCourses: string[];
+    };
+
+    expectTypeOf<actualPrimitives>().toEqualTypeOf<expectedPrimitives>();
+  });
+
+  it("should generate nested primitive object", () => {
+    type actualPrimitives = MutablePrimitives<User>;
+
+    type expectedPrimitives = {
+       address: {
+         city: string;
+         street: string;
+         number: number;
+      };
+    };
+
+    expectTypeOf<actualPrimitives>().toEqualTypeOf<expectedPrimitives>();
+  });
+
+  it("should generate nested primitive type from array of value objects prop", () => {
+    type actualPrimitives = MutablePrimitives<DeliveryInfo>;
+
+    type expectedPrimitives = {
+       addresses: {
+         city: string;
+         street: string;
+         number: number;
+      }[];
+    };
+
+    expectTypeOf<actualPrimitives>().toEqualTypeOf<expectedPrimitives>();
+  });
+
+  it("should get primitive type in case it is not a value object", () => {
+    type actualPrimitives = MutablePrimitives<Product>;
+
+    type expectedPrimitives = {
+       active: boolean;
+       createdAt: Date;
+    };
+
+    expectTypeOf<actualPrimitives>().toEqualTypeOf<expectedPrimitives>();
+  });
+
+  it("should infer the optional properties", () => {
+    type actualPrimitives = MutablePrimitives<Video>;
+
+    type expectedPrimitives = {
+       id: string;
+       name: string | undefined;
+       duration: number | undefined;
+    };
+
+    expectTypeOf<actualPrimitives>().toEqualTypeOf<expectedPrimitives>();
+  });
+});


### PR DESCRIPTION
When using Vue 3 to create a ref variable from a User class (a Value Object) in forms, it is not possible to create an editable object. To address this, create MutablePrimitives.ts for such cases.

Context:
![image](https://github.com/CodelyTV/typescript-primitives-type/assets/86814306/ece30568-2521-4993-9a68-b2a1e55a5d4c)

Class User:
![image](https://github.com/CodelyTV/typescript-primitives-type/assets/86814306/3db7353c-78ea-4d03-9ee8-7a079239d034)

Error: TypeScript asignable new values, conflict with property read-only
![image](https://github.com/CodelyTV/typescript-primitives-type/assets/86814306/6d9a1891-2db8-4222-a5d1-2f908763274c)

Now:
![image](https://github.com/CodelyTV/typescript-primitives-type/assets/86814306/77a8855e-099a-497e-9cdc-4630b3033de3)

Test:
![image](https://github.com/CodelyTV/typescript-primitives-type/assets/86814306/539c664f-7ae8-4064-92eb-56ad320d472c)
