### PR TITLE
fix: correct index.js path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codelytv/primitives-type",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Type entity primitives from value objects",
   "keywords": [
     "typescript",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "lint:fix": "npm run lint -- --fix",
     "test": "jest"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/CodelyTV/typescript-primitives-type"


### PR DESCRIPTION
Without this the imports are:
<img width="741" alt="image" src="https://github.com/user-attachments/assets/b1562a4a-eed4-4b93-be10-e39ec98f1c39">

This is because the [index.js root is inside `dist/src`](https://www.npmjs.com/package/@codelytv/primitives-type?activeTab=code) and not inside `dist` as the `package.json` signals.

I did this as a minor change, but this breaks how it has to be imported, so maybe this bugfix is a major bump?

This is failing since the 1.0.6 release: https://www.npmjs.com/package/@codelytv/primitives-type/v/1.0.6?activeTab=code